### PR TITLE
Fix AppArmor when not in live mode

### DIFF
--- a/etc/apparmor.d/tunables/home.d/live-mode
+++ b/etc/apparmor.d/tunables/home.d/live-mode
@@ -2,7 +2,7 @@
 ## Copyright (C) 2018 Algernon <33966997+Algernon-01@users.noreply.github.com>
 ## See the file COPYING for copying conditions.
 
-@{HOMEDIRS}+=/rw/home/
+# @{HOMEDIRS}+=/rw/home/
 alias / -> /rw/,
 alias /var/lib/ -> /rw/var/lib/,
 alias /var/lib/tor/ -> /rw/var/lib/tor/,

--- a/lib/systemd/system/live-mode-apparmor.service
+++ b/lib/systemd/system/live-mode-apparmor.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Fix AppArmor for live mode
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/live-mode-apparmor
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/live-mode-apparmor
+++ b/usr/lib/live-mode-apparmor
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## AppArmor profiles in live mode need the following line to work
+## but because of a bug in AppArmor, this breaks reloading profiles
+## so it is only enabled in live mode.
+
+if grep "boot=live" /proc/cmdline; then
+  sed -i 's/# @{HOMEDIRS}+=\/rw\/home/@{HOMEDIRS}+=\/rw\/home/' /etc/apparmor.d/tunables/home.d/live-mode
+fi


### PR DESCRIPTION
`@{HOMEDIRS}+=/rw/home/` causes errors when reloading profiles in AppArmor. This makes it so that line is only uncommented when using live mode.

See https://forums.whonix.org/t/live-mode-etc-apparmor-d-tunables-home-d-live-mode-breaks-aa-enforce/5868