### PR TITLE
Replace Ux rules in base abstraction

### DIFF
--- a/etc/apparmor.d/abstractions/base.anondist
+++ b/etc/apparmor.d/abstractions/base.anondist
@@ -233,7 +233,7 @@
   ## AppArmor feature request:
   ## allow adding permissions globally using drop-in .d folder
   ## https://gitlab.com/apparmor/apparmor/issues/50
-  /usr/lib/security-misc/permission-lockdown rUx,
-  /usr/lib/security-misc/pam_tally2-info rUx,
+  /usr/lib/security-misc/permission-lockdown rpx,
+  /usr/lib/security-misc/pam_tally2-info rpx,
 
   ## }} Whonix, Kicksecure, uwt, security-misc specific additions end here

--- a/etc/apparmor.d/usr.lib.security-misc.pam_tally2-info
+++ b/etc/apparmor.d/usr.lib.security-misc.pam_tally2-info
@@ -1,0 +1,32 @@
+#include <tunables/global>
+
+/usr/lib/security-misc/pam_tally2-info flags=(attach_disconnected) {
+  #include <abstractions/bash>
+
+  capability dac_override,
+  capability dac_read_search,
+
+  /bin/bash ix,
+  /bin/cat mrix,
+  /bin/grep mrix,
+  /usr/bin/cut mrix,
+  /usr/bin/tail mrix,
+  /sbin/pam_tally2 mrix,
+  /usr/lib/security-misc/pam_tally2-info r,
+
+  /etc/ld.so.cache r,
+  /etc/locale.alias r,
+
+  /{usr/,}lib{,32,64}/** mr,
+
+  owner /etc/nsswitch.conf r,
+  owner /etc/pam.d/* r,
+  owner /etc/passwd r,
+
+  owner /usr/share/zoneinfo/** r,
+  owner /var/log/tallylog rw,
+
+  /dev/tty rw,
+  owner /dev/pts/[0-9]* rw,
+
+}

--- a/etc/apparmor.d/usr.lib.security-misc.permission-lockdown
+++ b/etc/apparmor.d/usr.lib.security-misc.permission-lockdown
@@ -1,0 +1,33 @@
+#include <tunables/global>
+
+/usr/lib/security-misc/permission-lockdown flags=(attach_disconnected) {
+  #include <abstractions/bash>
+
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability fsetid,
+
+  /bin/bash ix,
+  /bin/chmod mrix,
+  /bin/echo mrix,
+  /bin/mkdir mrix,
+  /bin/touch mrix,
+  /usr/bin/basename mrix,
+  /usr/bin/touch mrix,
+  /usr/lib/security-misc/permission-lockdown r,
+
+  /home/*/ w,
+
+  /{usr/,}lib{,32,64}/** mr,
+
+  /etc/ld.so.cache r,
+  owner /etc/locale.alias r,
+  owner /etc/nsswitch.conf r,
+  owner /etc/passwd r,
+
+  owner /var/cache/security-misc/state-files/ rw,
+  owner /var/cache/security-misc/state-files/* rw,
+
+  /dev/tty rw,
+}


### PR DESCRIPTION
Instead of running the scripts unconfined, it now runs them in their own AppArmor profiles.